### PR TITLE
Setup: jspm executable name

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@ if [ $? != "0" ]; then
     exit 1
 fi
 
-test $(which jspm2)
+test $(which jspm)
 if [ $? != "0" ]; then
     echo -e "jspm not found: please run 'sudo npm install -g jspm'"
     exit 1


### PR DESCRIPTION
The setup script is looking for jspm2 but when following the instructions to follow jspm it creates an executable called just 'jspm'.
