### PR TITLE
Sort the events by date in reverse order

### DIFF
--- a/src/events-&-talks.ejs
+++ b/src/events-&-talks.ejs
@@ -36,7 +36,9 @@
                 <section class="dotted-top">
                     <h2>Recents talks by the Guardian</h2>
                     <ul class="l-grid l-tablet-grid l-tablet-grid--1of2 l-desktop-grid l-desktop-grid--1of3 base-list">
-                        <% scope.talks.forEach(function (talk) {
+                        <% scope.talks.sort(function(a, b) {
+                                return a.date > b.date ? -1: 1;
+                        }).forEach(function (talk) {
                             var author = scope.findAuthorByName(talk.authorName);
                             var talkLinkTitle = {
                                 'slides': 'View slides',


### PR DESCRIPTION
Latest events should be at the top of the page, otherwise initially it looks like we haven't given a talk since 2013.
