### PR TITLE
JS routing. Fixes #12

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -27,17 +27,27 @@ var urlParameters = constructURLQueryParameters({
 });
 var url = 'http://content.guardianapis.com/search?' + urlParameters;
 
-reqwest({
-    // TODO: API key
-    url: url,
-    type: 'jsonp'
-}).then(response => {
-    var renderedElement = renderTemplate(template, {
-        articles: response.response.results,
-        formatDate: dateString => moment(dateString).format('D MMM YYYY')
-    });
+function transcludeDeveloperBlog() {
+    reqwest({
+        // TODO: API key
+        url: url,
+        type: 'jsonp'
+    }).then(response => {
+        var renderedElement = renderTemplate(template, {
+            articles: response.response.results,
+            formatDate: dateString => moment(dateString).format('D MMM YYYY')
+        });
 
-    var developerBlogSectionDropZone = window.document.querySelector('.developer-blog-section .drop-zone');
-    developerBlogSectionDropZone.appendChild(renderedElement);
-    developerBlogSectionDropZone.hidden = false;
-});
+        var developerBlogSectionDropZone = window.document.querySelector('.developer-blog-section .drop-zone');
+        developerBlogSectionDropZone.appendChild(renderedElement);
+        developerBlogSectionDropZone.hidden = false;
+    });
+}
+
+switch(window.location.pathname) {
+    case '/' :
+        transcludeDeveloperBlog();
+        break;
+    default:
+        break;
+}


### PR DESCRIPTION
Very rudimentary JS routing using a switch statement against `window.location.pathname`. This fixes the js error being thrown on all pages other than the homepage as reported in issue #12 
