### PR TITLE
SEO optimisation for the Jobs page

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -86,9 +86,10 @@ var pages = [
         talks: talks
     },
     {
-        title: "Join the Guardian's development team",
+        title: "Join the Guardian’s development team",
+        menuTitle: "Join our team",
         fileBasename: 'join-the-team.ejs',
-        description: "The Guardian is the world's leading liberal voice, come join the team of developers behind the Pulitzer Prize-winning site theguardian.com",
+        description: "The Guardian is the world’s leading liberal voice, come join the team of developers behind the Pulitzer Prize-winning site theguardian.com",
         jobs: jobs
     }
 ];

--- a/src/head.ejs
+++ b/src/head.ejs
@@ -51,7 +51,7 @@
                             var hrefUrl = page.fileBasename.replace(/\.ejs$/, '.html'); %>
                             <li class="l-desktop-grid-cell l-grid-cell">
                                 <a href="<%= hrefUrl === 'index.html' ? './' : hrefUrl %>"
-                                   <% if (page.fileBasename === scope.fileBasename) { %> class="active" <% } %>><%= page.title %></a>
+                                   <% if (page.fileBasename === scope.fileBasename) { %> class="active" <% } %>><%= page.menuTitle ? page.menuTitle : page.title %></a>
                            </li>
                         <% }); %>
                     </ul>

--- a/src/join-the-team.ejs
+++ b/src/join-the-team.ejs
@@ -3,7 +3,7 @@
     <section>
         <div class="grey-widget trailing-margin">
             <div class="page-intro">
-                <h1>Join the Guardian's development team</h1>
+                <h1>Join the Guardian&rsquo;s development team</h1>
                 <p>We’re committed to a digital-first strategy, and in order to
                 achieve this, we’re expanding our team of developers.</p>
             </div>


### PR DESCRIPTION
The current jobs page on the site isn't going to generate a decent search listing and isn't going to beat the authority of jobs.theguardian.com. I've worked with the Audience team to make some changes that should make the page rank higher for people searching for development jobs and also to try and create a decent search listing for the page.

These changes are optimal for search but don't follow some of the conventions for the other pages, I think that's okay as this page has a specific job to do. However if it needs to be consistent then I would SEO the whole site rather than keep the current format.
