### PR TITLE
Remove Kaelig's lanyrd profile

### DIFF
--- a/src/content/authors.json
+++ b/src/content/authors.json
@@ -51,8 +51,7 @@
     {
         "name": "Kaelig Deloumeau-Prigent",
         "link": "https://twitter.com/kaelig",
-        "emailAddress": "kaelig@deloumeau.fr",
-        "lanyrd": "kaelig"
+        "emailAddress": "kaelig@deloumeau.fr",        
 	},
     {
         "name": "Grant Klopper",


### PR DESCRIPTION
He was appearing in our "Upcoming events section":

![google chrome 30](https://cloud.githubusercontent.com/assets/80089/5451655/2ee43326-850a-11e4-88c3-7445df2f1892.jpg)
