### PR TITLE
Add benefits to join-the-team

### DIFF
--- a/src/join-the-team.ejs
+++ b/src/join-the-team.ejs
@@ -23,6 +23,9 @@
 
             <p>The Guardian aims to ensure that all job applicants are treated fairly regardless of race (which includes nationality and ethnic or national origin), disability, sex, gender re-assignment, marital or civil partnership status, sexual orientation, perceived or actual age, maternity, pregnancy and religion or belief.</p>
 
+            <p>Some of the benefits that the Guardian can provide for employees include annual season ticket loan, childcare assistance vouchers, cycle to work scheme, gym membership and holiday purchase scheme. We also have a Pension scheme and some of our team work flexible hours - this is agreed on a case by case basis.</p>
+
+
 		    <p>Find out more about
 		    <a href="http://www.theguardian.com/info/developer-blog/2015/jan/20/how-does-the-guardian-recruit-developers">
 		    our recruitment process and what we're looking for</a>.


### PR DESCRIPTION
Adds benefits and possibility of flexible working to the `join-the-team` description. This is an action from the Diversity meeting, @sallygoble heard at a recent conference that flexible working / benefits can be an important factor. We offer these things so let's promote it. @sallygoble is going to chat to HR about adding this to specific job descriptions too.