### PR TITLE
Remove Oli and Seb's Lanyrd handles

### DIFF
--- a/src/content/authors.json
+++ b/src/content/authors.json
@@ -22,8 +22,7 @@
     {
         "name": "Sébastien Cevey",
         "link": "https://twitter.com/theefer",
-        "emailAddress": "seb.cevey@guardian.co.uk",
-        "lanyrd": "theefer"
+        "emailAddress": "seb.cevey@guardian.co.uk"
     },
     {
         "name": "Roberto Tyley",
@@ -44,8 +43,7 @@
     {
         "name": "Oliver Joseph Ash",
         "link": "https://twitter.com/oliverjash",
-        "emailAddress": "oliver.ash@guardian.co.uk",
-        "lanyrd": "oliverjash"
+        "emailAddress": "oliver.ash@guardian.co.uk"
     },
     {
         "name": "Kaelig Deloumeau-Prigent",


### PR DESCRIPTION
These are used for determining upcoming talks, so could lead to us adding their future talks by mistake.