### PR TITLE
remove GA tracking as we aren't sure we have consent

### DIFF
--- a/src/footer.ejs
+++ b/src/footer.ejs
@@ -19,13 +19,18 @@
             });
         </script>
         <script>
-            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-            })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+            // if we want tracking, look at https://github.com/guardian/support-frontend/pull/1672
+            // if we want a banner, look at https://github.com/guardian/support-frontend/pull/1677
+            const consented = false;
+            if (consented) {
+                (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-            ga('create', 'UA-52876985-1', 'auto');
-            ga('send', 'pageview');
+                ga('create', 'UA-52876985-1', 'auto');
+                ga('send', 'pageview');
+            }
 
         </script>
     </body>


### PR DESCRIPTION
https://trello.com/c/Fk4dS4ea/61-gdpr-add-cookie-consent-banner-or-remove-cookies

Not sure whether it's best to just remove the tracking section completely, but for now I've commented it out.
