### PR TITLE
add career progression framework

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -80,6 +80,10 @@ var pages = [
         jobs: jobs
     },
     {
+        title: 'Open People',
+        fileBasename: 'open-people.ejs'
+    },
+    {
         title: 'Open Source',
         fileBasename: 'open-source.ejs'
     },

--- a/src/open-people.ejs
+++ b/src/open-people.ejs
@@ -6,7 +6,7 @@
                 <h1>Open people</h1>
                 <p>Our culture of openness around people and processes gives us a common understanding of what we value.
                     It enables us to challenge and improve everything we do.  Although these don't change as often as
-                    our source code, they change with the needs of the team.</p>
+                    our source code, they do need to change as the team does.</p>
             </div>
         </div>
         <div class="inset">

--- a/src/open-people.ejs
+++ b/src/open-people.ejs
@@ -1,0 +1,44 @@
+<% include head %>
+<main class="trailing-margin">
+    <section>
+        <div class="grey-widget trailing-margin">
+            <div class="page-intro">
+                <h1>Open people</h1>
+                <p>Our culture of openness around people and processes gives us a common understanding of what we value.
+                    It enables us to challenge and improve everything we do.</p>
+            </div>
+        </div>
+        <div class="inset">
+            <div class="island">
+                <section class="dotted-top">
+                    <h2>Career Progression</h2>
+                    <div class="l-grid l-desktop-grid">
+                        <div class="l-desktop-grid-cell l-grid-cell l-desktop-1of3">
+                            <p>We aim to make everyone feel valued and give them a clear path to develop themselves at
+                                every stage of their career.  We publish our career progression information both internally
+                                and externally so that people can advance their career regardless of their background.</p>
+                        </div>
+                        <div class="l-desktop-grid-cell l-grid-cell">
+                            <ul class="base-list">
+                                <!--li class="trailing-margin">
+                                    <h3 class="alt-h3"><a href="#">
+                                            Career progression process and grading guidelines (TODO - awaiting link)
+                                        </a></h3>
+                                    <p>This is how we decide promotions and pay rises for everyone.</p>
+                                </li-->
+                                <li class="trailing-margin">
+                                    <h3 class="alt-h3"><a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vRqPMDtzJTvV1V42JyM4R_koBqnsoM9CY-yA2lGJF6c5tIpYVPVZwOnlGgQz2m7inar3_eSjiKlcww3/pubhtml">
+                                            Career progression framework
+                                        </a></h3>
+                                    <p>These tables help you to understand where you are now, and what
+                                    areas you would like to develop in to get to the role you want.</p>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </div>
+    </section>
+</main>
+<% include footer %>

--- a/src/open-people.ejs
+++ b/src/open-people.ejs
@@ -5,7 +5,8 @@
             <div class="page-intro">
                 <h1>Open people</h1>
                 <p>Our culture of openness around people and processes gives us a common understanding of what we value.
-                    It enables us to challenge and improve everything we do.</p>
+                    It enables us to challenge and improve everything we do.  Although these don't change as often as
+                    our source code, they change with the needs of the team.</p>
             </div>
         </div>
         <div class="inset">
@@ -14,7 +15,7 @@
                     <h2>Career Progression</h2>
                     <div class="l-grid l-desktop-grid">
                         <div class="l-desktop-grid-cell l-grid-cell l-desktop-1of3">
-                            <p>We aim to make everyone feel valued and give them a clear path to develop themselves at
+                            <p>We recognise people and give them a clear path to develop themselves at
                                 every stage of their career.  We publish our career progression information both internally
                                 and externally so that people can advance their career regardless of their background.</p>
                         </div>
@@ -32,6 +33,9 @@
                                         </a></h3>
                                     <p>These tables help you to understand where you are now, and what
                                     areas you would like to develop in to get to the role you want.</p>
+                                    <p>In the spirit of keeping our process up to date with the needs of the team, we are
+                                        making our career progression work better for everyone.  Expect some changes here in the coming
+                                        months.</p>
                                 </li>
                             </ul>
                         </div>

--- a/src/open-people.ejs
+++ b/src/open-people.ejs
@@ -21,12 +21,6 @@
                         </div>
                         <div class="l-desktop-grid-cell l-grid-cell">
                             <ul class="base-list">
-                                <!--li class="trailing-margin">
-                                    <h3 class="alt-h3"><a href="#">
-                                            Career progression process and grading guidelines (TODO - awaiting link)
-                                        </a></h3>
-                                    <p>This is how we decide promotions and pay rises for everyone.</p>
-                                </li-->
                                 <li class="trailing-margin">
                                     <h3 class="alt-h3"><a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vRqPMDtzJTvV1V42JyM4R_koBqnsoM9CY-yA2lGJF6c5tIpYVPVZwOnlGgQz2m7inar3_eSjiKlcww3/pubhtml">
                                             Career progression framework


### PR DESCRIPTION
This PR adds the new section for openness around people stuff.  I have adde the career progression framework as the first step covering only SETI and engineering

The main thing to review is the link referenced that is public https://docs.google.com/spreadsheets/d/e/2PACX-1vRqPMDtzJTvV1V42JyM4R_koBqnsoM9CY-yA2lGJF6c5tIpYVPVZwOnlGgQz2m7inar3_eSjiKlcww3/pubhtml

Screenshot of the new page:
![image](https://user-images.githubusercontent.com/7304387/54752078-b8609c80-4bd4-11e9-894c-34955918ee60.png)


@franziskas @AlexTellman 