### PR TITLE
add how we promote engineers link to the open people section

### DIFF
--- a/src/open-people.ejs
+++ b/src/open-people.ejs
@@ -22,11 +22,24 @@
                         <div class="l-desktop-grid-cell l-grid-cell">
                             <ul class="base-list">
                                 <li class="trailing-margin">
+                                    <h3 class="alt-h3"><a href="https://docs.google.com/document/d/e/2PACX-1vSyvQgYaTqAgaiaORShaqhWod2MsyS3iugypeBjyxP4Y9i676DcYvzgBH4YHYl-l8p3A8IU2UOA14Jr/pub">
+                                            How we promote engineers
+                                        </a></h3>
+                                    <p>We use this internally to ensure every engineer in the department understands
+                                        our career progression process, and for that process to be clear and consistent to everyone.<br>
+                                        There may seem to be a lot of detail there, but this is because we take a lot of
+                                        effort to make it fair and consistent.
+                                    </p>
+                                    <p>In the spirit of keeping our process up to date with the needs of the team, we are
+                                        making our career progression work better for everyone.  Expect some changes here in the coming
+                                        months.</p>
+                                </li>
+                                <li class="trailing-margin">
                                     <h3 class="alt-h3"><a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vRqPMDtzJTvV1V42JyM4R_koBqnsoM9CY-yA2lGJF6c5tIpYVPVZwOnlGgQz2m7inar3_eSjiKlcww3/pubhtml">
-                                            Career progression framework
+                                            Career progression grid
                                         </a></h3>
                                     <p>These tables help you to understand where you are now, and what
-                                    areas you would like to develop in to get to the role you want.</p>
+                                        areas you would like to develop in to get to the role you want.</p>
                                     <p>In the spirit of keeping our process up to date with the needs of the team, we are
                                         making our career progression work better for everyone.  Expect some changes here in the coming
                                         months.</p>


### PR DESCRIPTION
I have added a link to the how we promote engineers document.  I had to make a copy as the document owner is not available to grant access.  However we can solve that in future.

The new section is highlighted in red in this screenshot and the link goes [here](https://docs.google.com/document/d/e/2PACX-1vSyvQgYaTqAgaiaORShaqhWod2MsyS3iugypeBjyxP4Y9i676DcYvzgBH4YHYl-l8p3A8IU2UOA14Jr/pub)
![image](https://user-images.githubusercontent.com/7304387/55414624-5e13f400-5563-11e9-92fa-c1607a2a4594.png)

There are actually 2 cards I found, one from @franziskas 
https://trello.com/c/3wmd5LuN/38-add-progression-framework-promotion-criteria-on-the-developer-site
and one from @LATaylor-guardian 
https://trello.com/c/HNzRUtGh/48-add-our-how-we-promote-engineers-piece-of-content-under-the-engineering-culture-section-this-will-also-publicly-add-our-career-p
so I think this is the second part of both cards.

Reviews/+1s appreciated!