### PR TITLE
track people who have opted in

### DIFF
--- a/src/footer.ejs
+++ b/src/footer.ejs
@@ -21,7 +21,11 @@
         <script>
             // if we want tracking, look at https://github.com/guardian/support-frontend/pull/1672
             // if we want a banner, look at https://github.com/guardian/support-frontend/pull/1677
-            const consented = false;
+            let consented = false;
+            const consentCookieMaybe = document.cookie.split(';').find(c => c.includes('GU_TK'));
+            if(consentCookieMaybe) {
+                consented = consentCookieMaybe.split('=').pop().split('.')[0] === '1'
+            }
             if (consented) {
                 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
                     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
since https://github.com/guardian/developers-site/pull/103 we took out the tracking
this pr adds back in tracking only to people who have opted in previously on theguardian domain.

The next PR will actually add the banner for people who haen't yet opted in.

Thanks to @walaura for knowing how to do this and pairing! 🥇 

Trello: https://trello.com/c/miPU34Vn/62-add-google-analytics-and-consent-banner