### PR TITLE
Consent banner for developer site

### DIFF
--- a/src/css/components/consent.scss
+++ b/src/css/components/consent.scss
@@ -1,0 +1,46 @@
+.consent {
+    position: fixed;
+    background: #474747;
+    color: #ffffff;
+    bottom: 0;
+    left:0;
+    right: 0;
+
+    a {
+        color: inherit;
+    }
+}
+
+.consent__intro {
+    @include breakpoint($desktop) {
+        max-width: 66%;
+    }
+}
+
+
+.consent__button {
+    font-family: "AgateSans", sans-serif;
+    background: #0cb9d4;
+    font-size: 1.1rem;
+    border: 0;
+    cursor: pointer;
+    color: #ffffff;
+    font-weight: 600;
+    padding: .75rem 1.25rem;
+    border-radius: 100em;
+    svg {
+        height: .8em;
+        width: auto;
+        margin-right: .5rem;
+        margin-left: -.25em;
+    }
+}
+
+
+.consent__actions {
+    margin-top: 1.5rem;
+
+    .consent__button {
+        margin-right: 1rem;
+    }
+}

--- a/src/css/components/consent.scss
+++ b/src/css/components/consent.scss
@@ -11,6 +11,10 @@
     }
 }
 
+.consent--hidden {
+    display: none;
+}
+
 .consent__intro {
     @include breakpoint($desktop) {
         max-width: 66%;

--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -21,6 +21,7 @@ $trailing-margin-height: 1.5rem;
 @import "base";
 
 @import "components/main-image";
+@import "components/consent";
 
 .inset {
     @include breakpoint($desktop) {

--- a/src/footer.ejs
+++ b/src/footer.ejs
@@ -10,6 +10,14 @@
                 © Guardian News and Media Limited or its affiliated companies. All rights reserved.
             </div>
         </footer>
+        <div class="gdpr-consent">
+            <div class="inset">
+                <div class="site-message--first-pv-consent__block site-message--first-pv-consent__block--intro">
+                    <p>We use cookies to improve your experience on our site and to show you personalised advertising.</p>
+                    <p>To find out more, read our <a class="u-underline" data-link-name="first-pv-consent : to-privacy" href="https://www.theguardian.com/help/privacy-policy">privacy policy</a> and <a class="u-underline" data-link-name="first-pv-consent : to-cookies" href="https://www.theguardian.com/info/cookies">cookie policy</a>.</p>
+                </div>
+            </div>
+        </div>
         <script async>
             /* global System */
             System.import('js/app').catch(function(e) {

--- a/src/footer.ejs
+++ b/src/footer.ejs
@@ -10,7 +10,7 @@
                 © Guardian News and Media Limited or its affiliated companies. All rights reserved.
             </div>
         </footer>
-        <div class="consent">
+        <div class="consent js-consent consent--hidden">
             <div class="inset"><div class="island">
                 <h2>Your privacy</h2>
                 <div class="consent__intro">
@@ -18,7 +18,7 @@
                     <p>To find out more, read our <a class="u-underline" data-link-name="first-pv-consent : to-privacy" href="https://www.theguardian.com/help/privacy-policy">privacy policy</a> and <a class="u-underline" data-link-name="first-pv-consent : to-cookies" href="https://www.theguardian.com/info/cookies">cookie policy</a>.</p>
                 </div>
                 <div class="consent__actions">
-                    <button class="consent__button"><span class="inline-tick inline-icon"><svg width="10.79" height="8.608" viewBox="0 0 10.79 8.608"><path fill="#fff" d="M2.987 6.575L10.244 0l.546.532-7.803 8.076h-.26L0 4.788l.545-.546 2.442 2.333z"></path></svg></span><span>I'm OK with that</span></button>
+                    <button class="js-consent-button consent__button"><span class="inline-tick inline-icon"><svg width="10.79" height="8.608" viewBox="0 0 10.79 8.608"><path fill="#fff" d="M2.987 6.575L10.244 0l.546.532-7.803 8.076h-.26L0 4.788l.545-.546 2.442 2.333z"></path></svg></span><span>I'm OK with that</span></button>
                     <a href="https://profile.theguardian.com/privacy-settings">My options</a>
                 </div>
             </div></div>
@@ -32,22 +32,71 @@
             });
         </script>
         <script>
-            // if we want tracking, look at https://github.com/guardian/support-frontend/pull/1672
-            // if we want a banner, look at https://github.com/guardian/support-frontend/pull/1677
-            let consented = false;
-            const consentCookieMaybe = document.cookie.split(';').find(c => c.includes('GU_TK'));
-            if(consentCookieMaybe) {
-                consented = consentCookieMaybe.split('=').pop().split('.')[0] === '1'
+            function getCookieDateString(now) {
+                const days = 30 * 18;
+                const millisPerDay = 24 * 60 * 60 * 1000;
+                const date = new Date(now + (days * millisPerDay));
+                return date.toGMTString();
             }
-            if (consented) {
+
+            function askForConsent() {
+                return new Promise((accept, reject) => {
+                    const $consentBanner = document.querySelector('.js-consent');
+                    const $consentButton = document.querySelector('.js-consent-button');
+                    if ($consentBanner && $consentButton) {
+                        $consentBanner.classList.remove('consent--hidden');
+                        $consentButton.addEventListener('click', () => {
+                            const cookieValue = '1.' + Date.now();
+                            const expiry = getCookieDateString(Date.now())
+                            document.cookie = [
+                                `GU_TK=${cookieValue}`,
+                                `domain=theguardian.com`,
+                                `expires=${expiry}`,
+                                `path=/`
+                            ].join(`; `);
+                            $consentBanner.classList.add('consent--hidden');
+                            accept();
+                        });
+                    } else {
+                        reject();
+                    }
+                });
+
+            }
+
+            function startTracking() {
                 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
                     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
                 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
                 ga('create', 'UA-52876985-1', 'auto');
                 ga('send', 'pageview');
             }
+
+            function hasConsentedFromCookie() {
+                let consented = 'NO_CHOICE';
+                const consentCookieMaybe = document.cookie.split(';').find(c => c.includes('GU_TK'));
+                if(consentCookieMaybe) {
+                    consented = consentCookieMaybe.split('=').pop().split('.')[0] === '1' ? 'CONSENTED' : 'REJECTED'
+                }
+                return consented;
+            }
+
+            function hasConsented() {
+                const consented = hasConsentedFromCookie();
+                if(consented === 'CONSENTED') {
+                    return Promise.resolve()
+                }
+                else if (consented === 'NO_CHOICE') {
+                    return askForConsent();
+                }
+                return Promise.reject(consented);
+            }
+
+            hasConsented().then(() => {startTracking()}).catch((err) => {
+                console.error(err, 'The consent banner did not work!');
+            });
 
         </script>
     </body>

--- a/src/footer.ejs
+++ b/src/footer.ejs
@@ -10,13 +10,18 @@
                 © Guardian News and Media Limited or its affiliated companies. All rights reserved.
             </div>
         </footer>
-        <div class="gdpr-consent">
-            <div class="inset">
-                <div class="site-message--first-pv-consent__block site-message--first-pv-consent__block--intro">
+        <div class="consent">
+            <div class="inset"><div class="island">
+                <h2>Your privacy</h2>
+                <div class="consent__intro">
                     <p>We use cookies to improve your experience on our site and to show you personalised advertising.</p>
                     <p>To find out more, read our <a class="u-underline" data-link-name="first-pv-consent : to-privacy" href="https://www.theguardian.com/help/privacy-policy">privacy policy</a> and <a class="u-underline" data-link-name="first-pv-consent : to-cookies" href="https://www.theguardian.com/info/cookies">cookie policy</a>.</p>
                 </div>
-            </div>
+                <div class="consent__actions">
+                    <button class="consent__button"><span class="inline-tick inline-icon"><svg width="10.79" height="8.608" viewBox="0 0 10.79 8.608"><path fill="#fff" d="M2.987 6.575L10.244 0l.546.532-7.803 8.076h-.26L0 4.788l.545-.546 2.442 2.333z"></path></svg></span><span>I'm OK with that</span></button>
+                    <a href="https://profile.theguardian.com/privacy-settings">My options</a>
+                </div>
+            </div></div>
         </div>
         <script async>
             /* global System */


### PR DESCRIPTION
This adds the consent banner!  Thanks so much to @walaura for basically showing me how to do it patiently! (Sorry I tried to add you to all the commits but I messed up my local git by trying to rebase old commit messages.)

No cookies causes no tracking while the banner is active:
![image](https://user-images.githubusercontent.com/7304387/55492447-1f4b7000-562f-11e9-98bd-88a7dbd073f1.png)
After clicking it runs GA straight away, but if you have opted out (GU_TK is 0) then it won't ask at all or do any tracking.