### PR TITLE
Replace developer team video with new version

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -55,12 +55,14 @@
                         <section class="content blue-widget">
                             <div class="video">
                                 <div class="video__placeholder"></div>
-                                <iframe src="https://player.vimeo.com/video/84380461?title=0&amp;byline=0&amp;portrait=0"
+                                <iframe width="1420" height="517"
+                                        class="video__iframe"
+                                        src="https://www.youtube.com/embed/OP1LHwOBWHA"
                                         frameborder="0"
-                                        webkitallowfullscreen
-                                        mozallowfullscreen
+                                        allow="encrypted-media; picture-in-picture"
                                         allowfullscreen
-                                        class="video__iframe"></iframe>
+                                        webkitallowfullscreen
+                                        mozallowfullscreen></iframe>
                             </div>
                             <div class="island">
                                 <h2 class="h3">What’s it like to work at the Guardian?</h2>


### PR DESCRIPTION
Replace old video with more recent developer conversations - fits with the same dimensions as the original video at a variety of browser widths.

![image](https://user-images.githubusercontent.com/5294853/57848608-3609e880-77d1-11e9-938b-6bdb89927123.png)

![image](https://user-images.githubusercontent.com/5294853/57848774-94cf6200-77d1-11e9-85f9-717c43d95e4c.png)

![image](https://user-images.githubusercontent.com/5294853/57848789-a0228d80-77d1-11e9-8a78-171decdef790.png)

