### PR TITLE
update fonts

### DIFF
--- a/src/css/main.scss
+++ b/src/css/main.scss
@@ -63,7 +63,7 @@ $trailing-margin-height: 1.5rem;
 }
 
 .sans-serif {
-    font-family: "AgateSans", sans-serif;
+    font-family: "GuardianTextSans", sans-serif;
 }
 
 .cta-link {
@@ -283,7 +283,7 @@ $trailing-margin-height: 1.5rem;
     }
 
     .jobs__link {
-        font-family: "AgateSans", sans-serif;
+        font-family: "GuardianTextSans", sans-serif;
         background: #0cb9d4;
         font-size: 1.1rem;
         padding: 0 1.25rem;

--- a/src/css/typography.scss
+++ b/src/css/typography.scss
@@ -1,5 +1,5 @@
 body {
-    font-family: "EgyptianText", "Georgia", serif;
+    font-family: "GuardianTextEgyptian", "Georgia", serif;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
     color: hsl(0, 0%, 13%);
@@ -34,7 +34,7 @@ h3,
 h4,
 h5,
 h6 {
-    font-family: "EgyptianHeadline", "Georgia", serif;
+    font-family: "GH Guardian Headline", "Georgia", serif;
 
     a {
         text-decoration: none;
@@ -68,7 +68,7 @@ h4 {
 }
 
 time {
-    font-family: "AgateSans", sans-serif;
+    font-family: "GuardianTextSans", sans-serif;
     font-size: smaller;
     color: hsl(0, 0%, 50%);
 }

--- a/src/css/webfonts.scss
+++ b/src/css/webfonts.scss
@@ -1,55 +1,90 @@
 @font-face {
-    font-family: "AgateSans";
-    src: url("https://pasteup.guim.co.uk/fonts/latin1/Guardian-Ag-Sans-1-Web-Reg.woff") format("woff");
-    font-weight: normal;
-    font-style: normal;
-    font-stretch: normal;
+	font-family: 'GuardianTextSans';
+	src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff2')
+			format('woff2'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/noalts-not-hinted/GuardianTextSans-Regular.woff')
+			format('woff'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textsans/latin1-not-hinted/GuardianTextSans-Regular.ttf')
+			format('truetype');
+	font-weight: normal;
+	font-style: normal;
+	font-display: swap;
 }
 
 @font-face {
-    font-family: "EgyptianText";
-    src: url("https://pasteup.guim.co.uk/fonts/WebEgyptianHinted-Regular.woff") format("woff");
-    font-weight: normal;
-    font-style: normal;
-    font-stretch: normal;
+	font-family: 'GuardianTextEgyptian';
+	src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2')
+			format('woff2'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff')
+			format('woff'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Regular.ttf')
+			format('truetype');
+	font-weight: normal;
+	font-style: normal;
+	font-display: swap;
 }
 
 @font-face {
-    font-family: "EgyptianText";
-    src: url("https://pasteup.guim.co.uk/fonts/WebEgyptianHinted-RegularItalic.woff") format("woff");
-    font-weight: normal;
-    font-style: italic;
-    font-stretch: normal;
+	font-family: 'GuardianTextEgyptian';
+	src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-RegularItalic.woff2')
+			format('woff2'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-RegularItalic.woff')
+			format('woff'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-RegularItalic.ttf')
+			format('truetype');
+	font-weight: normal;
+	font-style: italic;
+	font-display: swap;
 }
 
 @font-face {
-    font-family: "EgyptianText";
-    src: url("https://pasteup.guim.co.uk/fonts/latin1/Guardian-Text-Egyp-Web-Med.woff") format("woff");
-    font-weight: 700;
-    font-style: normal;
-    font-stretch: normal;
+	font-family: 'GuardianTextEgyptian';
+	src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Bold.woff2')
+			format('woff2'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Bold.woff')
+			format('woff'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/latin1-not-hinted/GuardianTextEgyptian-Bold.ttf')
+			format('truetype');
+	font-weight: 700;
+	font-style: normal;
+	font-display: swap;
 }
 
 @font-face {
-    font-family: "EgyptianHeadline";
-    src: url("https://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Light.woff") format("woff");
-    font-weight: 200;
-    font-style: normal;
-    font-stretch: normal;
+	font-family: 'GH Guardian Headline';
+	src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Light.woff2')
+			format('woff2'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Light.woff')
+			format('woff'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Light.ttf')
+			format('truetype');
+	font-weight: 200;
+	font-style: normal;
+	font-display: swap;
 }
 
 @font-face {
-    font-family: "EgyptianHeadline";
-    src: url("https://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Regular.woff") format("woff");
-    font-weight: normal;
-    font-style: normal;
-    font-stretch: normal;
+	font-family: 'GH Guardian Headline';
+	src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Regular.woff2')
+			format('woff2'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Regular.woff')
+			format('woff'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Regular.ttf')
+			format('truetype');
+	font-weight: normal;
+	font-style: normal;
+	font-display: swap;
 }
 
 @font-face {
-    font-family: "EgyptianHeadline";
-    src: url("https://pasteup.guim.co.uk/fonts/latin1/Guardian-Egyp-Web-Semibold.woff") format("woff");
-    font-weight: 900;
-    font-style: normal;
-    font-stretch: normal;
+	font-family: 'GH Guardian Headline';
+	src: url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Black.woff2')
+			format('woff2'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Black.woff')
+			format('woff'),
+		url('https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/latin1-not-hinted/GHGuardianHeadline-Black.ttf')
+			format('truetype');
+	font-weight: 900;
+	font-style: normal;
+	font-display: swap;
 }


### PR DESCRIPTION
updates the fonts to point at the official endpoint.

also removes use of agate, for which we do not have a license outside of internal tooling.

i cannot get the site to run locally, so i don't know how it looks...